### PR TITLE
Fix broken Debug mode due to bad .egg path

### DIFF
--- a/src/main/java/data/BlenderToolWindowUtils.java
+++ b/src/main/java/data/BlenderToolWindowUtils.java
@@ -1,25 +1,12 @@
 package data;
 
+import com.intellij.openapi.application.PathManager;
+
 import java.io.File;
-import java.net.URL;
 
 public class BlenderToolWindowUtils {
-
-    public static File getJarPath() {
-        URL x = BlenderToolWindowUtils.class.getClassLoader().getResource("debugger");
-        if (x == null) return null;
-        return new File(x.getPath().split("/", 2)[1].split(".jar!")[0] + ".jar");
-    }
-
-    public static File getIdePath() {
-        File jar = getJarPath();
-        if (jar == null) return null;
-        return getJarPath().getParentFile().getParentFile();
-    }
-
     public static File getEggFile() {
-        File ide = getIdePath();
-        if (ide == null) return null;
-        return new File(ide.getPath() + File.separator + "debug-eggs" + File.separator + "pydevd-pycharm.egg");
+        String ide = PathManager.getHomePath();
+        return new File(ide + File.separator + "debug-eggs" + File.separator + "pydevd-pycharm.egg");
     }
 }


### PR DESCRIPTION
This patch addresses issues #17, #11, and #9 with a simple fix for the Debug mode. Currently, computing the path to the `pydevd-pycharm.egg` file can fail, effectively disabling the Python remote debug server on the Blender side.

Instead of computing the .egg file path by trying to guess it from a Java class source file parent directory, the IDE root folder is now directly obtained from the IntelliJ SDK.

Tested and confirmed to work on macOS 13.4.1, using PyCharm Professional Edition 2023.2 and Blender 3.6